### PR TITLE
Add dockerfile para criar imagem da api no docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+WORKDIR /source
+
+# copy csproj and restore as distinct layers
+COPY Back-End/*.csproj .
+RUN dotnet restore --use-current-runtime  
+
+# copy everything else and build app
+COPY Back-End/. .
+RUN dotnet publish --use-current-runtime --self-contained false --no-restore -o /app
+
+
+# final stage/image
+FROM mcr.microsoft.com/dotnet/aspnet:7.0
+WORKDIR /app
+COPY --from=build /app .
+ENTRYPOINT ["dotnet", "Back-End.dll"]


### PR DESCRIPTION
Time Devops criou arquivo chamado Dockerfile para a criação da imagem da api em docker.